### PR TITLE
Support collection Initializer with D2Shapes

### DIFF
--- a/src/D2Shape.cs
+++ b/src/D2Shape.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+
 namespace d2;
 
 public record class D2Shape(
@@ -6,7 +8,7 @@ public record class D2Shape(
   Shape? Shape = default,
   D2Style? Style = default,
   string? Near = default
-)
+) : IEnumerable<D2Shape>, IEnumerable<D2Connection>, IEnumerable<D2Text>
 {
   private readonly List<D2Shape> _shapes = new();
   private readonly List<D2Connection> _connections = new();
@@ -53,4 +55,16 @@ public record class D2Shape(
 
   public override string ToString()
     => string.Join(Environment.NewLine, Lines());
+
+    public IEnumerator<D2Shape> GetEnumerator()
+		=> _shapes.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator()
+		=> GetEnumerator();
+
+    IEnumerator<D2Text> IEnumerable<D2Text>.GetEnumerator()
+		=> _texts.GetEnumerator();
+
+    IEnumerator<D2Connection> IEnumerable<D2Connection>.GetEnumerator()
+		=> _connections.GetEnumerator();
 }

--- a/test/UnitTests.cs
+++ b/test/UnitTests.cs
@@ -10,8 +10,8 @@ public class UnitTests
     var company = new D2Shape("google", "Google", Shape.Rectangle)
 	{
 		new D2Shape("gmail", "Gmail", Shape.Rectangle),
-			new D2Shape("meet", "Meet", Shape.Rectangle),
-			new D2Shape("deepmind", "DeepMind", Shape.Rectangle),
+		new D2Shape("meet", "Meet", Shape.Rectangle),
+		new D2Shape("deepmind", "DeepMind", Shape.Rectangle),
 	};
 
     var connection = new D2Connection(company.Name, umbrella.Name, Direction.TO, "BELONGS_TO");

--- a/test/UnitTests.cs
+++ b/test/UnitTests.cs
@@ -7,11 +7,12 @@ public class UnitTests
   public void TestDiagram()
   {
     var umbrella = new D2Shape("alphabet", "Alphabet Inc", Shape.Rectangle);
-    var company = new D2Shape("google", "Google", Shape.Rectangle);
-
-    company.Add(new D2Shape("gmail", "Gmail", Shape.Rectangle));
-    company.Add(new D2Shape("meet", "Meet", Shape.Rectangle));
-    company.Add(new D2Shape("deepmind", "DeepMind", Shape.Rectangle));
+    var company = new D2Shape("google", "Google", Shape.Rectangle)
+	{
+		new D2Shape("gmail", "Gmail", Shape.Rectangle),
+			new D2Shape("meet", "Meet", Shape.Rectangle),
+			new D2Shape("deepmind", "DeepMind", Shape.Rectangle),
+	};
 
     var connection = new D2Connection(company.Name, umbrella.Name, Direction.TO, "BELONGS_TO");
 
@@ -34,6 +35,6 @@ google: Google {
 }
 google -> alphabet: BELONGS_TO";
 
-    Assert.AreSame(expected, actual);
+    Assert.AreEqual(expected, actual);
   }
 }


### PR DESCRIPTION
Adding the support Collection Initializers to `D2Shape` so that it is more similar to the actual `D2` format and is more convenient to write.

For example, instead of:
```csharp
var company = new D2Shape("google", null, Shape.Rectangle);

company.Add(new D2Shape("gmail", "Gmail", Shape.Rectangle));
company.Add(new D2Shape("meet", "Meet", Shape.Rectangle));
company.Add(new D2Shape("deepmind", "DeepMind", Shape.Rectangle));
```

We can now do
```csharp
var company = new D2Shape("google", "Google", Shape.Rectangle)
{
    new D2Shape("gmail", "Gmail", Shape.Rectangle),
    new D2Shape("meet", "Meet", Shape.Rectangle),
    new D2Shape("deepmind", "DeepMind", Shape.Rectangle),
};
```