### PR TITLE
Make D2 serialization safe

### DIFF
--- a/src/D2Connection.cs
+++ b/src/D2Connection.cs
@@ -9,10 +9,10 @@ public record class D2Connection(
 {
   internal IEnumerable<string> Lines()
   {
-    var @base = $"{First} {Direction} {Second}";
+    var @base = $"{D2Writer.Reference(First)} {Direction} {D2Writer.Reference(Second)}";
     if (!string.IsNullOrWhiteSpace(Label))
     {
-      @base += $": {Label}";
+      @base += $": {D2Writer.String(Label)}";
     }
 
     return new List<string> { @base };

--- a/src/D2Shape.cs
+++ b/src/D2Shape.cs
@@ -32,7 +32,7 @@ public record class D2Shape(
 
     if (!string.IsNullOrWhiteSpace(Icon))
     {
-      properties.Add($"icon: {Icon}");
+      properties.Add($"icon: {D2Writer.String(Icon)}");
     }
 
     if (Shape is not null)
@@ -42,7 +42,7 @@ public record class D2Shape(
 
     if (!string.IsNullOrEmpty(Near))
     {
-      properties.Add($"near: {Near}");
+      properties.Add($"near: {D2Writer.String(Near)}");
     }
 
     if (Style is not null)
@@ -50,7 +50,7 @@ public record class D2Shape(
       properties.AddRange(Style.Lines());
     }
 
-    return Utils.AddLabelAndProperties(Name, Label, properties);
+    return D2Writer.Object(Name, Label, properties);
   }
 
   public override string ToString()

--- a/src/D2Style.cs
+++ b/src/D2Style.cs
@@ -5,26 +5,32 @@ public record class D2Style(
   int? StrokeWidth,
   string? Fill,
   bool? Shadow,
-  int? Opacity,
+  double? Opacity,
   int? StrokeDash,
   bool? ThreeD
 )
 {
   public IEnumerable<string> Lines()
   {
+    if (Opacity is { } opacity &&
+      (double.IsNaN(opacity) || double.IsInfinity(opacity) || opacity is < 0 or > 1))
+    {
+      throw new ArgumentOutOfRangeException(nameof(Opacity), Opacity, "Opacity must be between 0 and 1.");
+    }
+
     var styles = new List<string>();
 
-    if (Stroke is not null) styles.Add($"stroke: {Stroke}");
-    if (StrokeWidth is not null) styles.Add($"stroke-width: {StrokeWidth}");
-    if (Fill is not null) styles.Add($"fill: {Fill}");
-    if (Shadow is not null) styles.Add($"shadow: {Utils.StringifyBoolean(Shadow)}");
-    if (Opacity is not null) styles.Add($"opacity: {Opacity}");
-    if (StrokeDash is not null) styles.Add($"stroke-dash: {StrokeDash}");
-    if (ThreeD is not null) styles.Add($"3d: {Utils.StringifyBoolean(ThreeD)}");
+    if (Stroke is not null) styles.Add($"stroke: {D2Writer.String(Stroke)}");
+    if (StrokeWidth is not null) styles.Add($"stroke-width: {D2Writer.Integer(StrokeWidth.Value)}");
+    if (Fill is not null) styles.Add($"fill: {D2Writer.String(Fill)}");
+    if (Shadow is not null) styles.Add($"shadow: {D2Writer.Boolean(Shadow.Value)}");
+    if (Opacity is not null) styles.Add($"opacity: {D2Writer.Number(Opacity.Value)}");
+    if (StrokeDash is not null) styles.Add($"stroke-dash: {D2Writer.Integer(StrokeDash.Value)}");
+    if (ThreeD is not null) styles.Add($"3d: {D2Writer.Boolean(ThreeD.Value)}");
 
     return styles.Count == 0
       ? new List<string>()
-      : Utils.AddLabelAndProperties("style", null, styles);
+      : D2Writer.Object("style", null, styles);
   }
 
   public override string ToString()

--- a/src/D2Text.cs
+++ b/src/D2Text.cs
@@ -9,13 +9,35 @@ public record D2Text(
 {
   internal IEnumerable<string> Lines()
   {
-    var sep = "|".Repeat(Pipes);
+    if (Pipes < 1)
+    {
+      throw new ArgumentOutOfRangeException(nameof(Pipes), Pipes, "A block string delimiter needs at least one pipe.");
+    }
 
-    return new List<string>()
-      .Append($"{Property}:{sep}{Format}")
-      .Concat(Text.Split(Environment.NewLine))
-      .Append(sep);
+    if (string.IsNullOrWhiteSpace(Format) || !Format.All(IsAsciiFormatCharacter))
+    {
+      throw new ArgumentException("The block string format must contain only ASCII letters, digits, underscores, or hyphens.", nameof(Format));
+    }
+
+    var textLines = D2Writer.Lines(Text);
+    var pipeCount = Pipes;
+    while (textLines.Contains(new string('|', pipeCount), StringComparer.Ordinal))
+    {
+      pipeCount++;
+    }
+
+    var separator = new string('|', pipeCount);
+
+    return new[] { $"{D2Writer.Reference(Property)}:{separator}{Format}" }
+      .Concat(textLines)
+      .Append(separator);
   }
+
+  private static bool IsAsciiFormatCharacter(char value)
+    => value is >= 'a' and <= 'z'
+      or >= 'A' and <= 'Z'
+      or >= '0' and <= '9'
+      or '_' or '-';
 
   public override string ToString()
     => string.Join(Environment.NewLine, Lines());

--- a/src/D2Writer.cs
+++ b/src/D2Writer.cs
@@ -1,0 +1,130 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace d2;
+
+/// <summary>
+/// Serializes values into D2 syntax. Keeping these rules in one place prevents
+/// individual model types from accidentally emitting user input as D2 code.
+/// </summary>
+internal static class D2Writer
+{
+  private static readonly Regex BareIdentifier = new(
+    "^[\\p{L}_][\\p{L}\\p{N}_-]*$",
+    RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+  private static readonly Regex BareString = new(
+    "^[\\p{L}\\p{N}_][\\p{L}\\p{N} _./-]*$",
+    RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+  internal static string Reference(string value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      throw new ArgumentException("A D2 reference cannot be null, empty, or whitespace.", nameof(value));
+    }
+
+    // A dot is meaningful in D2: it navigates to a nested object. Quote each
+    // segment independently so path semantics survive without allowing a
+    // segment's contents to become syntax.
+    return string.Join(".", value.Split('.').Select(IdentifierSegment));
+  }
+
+  internal static string String(string value)
+  {
+    if (value is null)
+    {
+      throw new ArgumentNullException(nameof(value));
+    }
+
+    return BareString.IsMatch(value) ? value : Quoted(value);
+  }
+
+  internal static string Boolean(bool value) => value ? "true" : "false";
+
+  internal static string Integer(int value) => value.ToString(CultureInfo.InvariantCulture);
+
+  internal static string Number(double value) => value.ToString("R", CultureInfo.InvariantCulture);
+
+  internal static IEnumerable<string> Object(
+    string name,
+    string? label,
+    IEnumerable<string>? properties)
+  {
+    var propertyLines = properties?.ToList() ?? new List<string>();
+    var hasProperties = propertyLines.Count > 0;
+    var firstLine = Reference(name);
+
+    if (label is not null || hasProperties)
+    {
+      firstLine += ":";
+    }
+
+    if (label is not null)
+    {
+      firstLine += $" {String(label)}";
+    }
+
+    if (hasProperties)
+    {
+      firstLine += " {";
+      return new[] { firstLine }.Concat(Indent(propertyLines)).Append("}");
+    }
+
+    return new[] { firstLine };
+  }
+
+  internal static IEnumerable<string> Indent(IEnumerable<string> lines, int spaces = 2)
+  {
+    if (lines is null)
+    {
+      throw new ArgumentNullException(nameof(lines));
+    }
+
+    if (spaces < 0)
+    {
+      throw new ArgumentOutOfRangeException(nameof(spaces), spaces, "Indentation cannot be negative.");
+    }
+
+    var indentation = new string(' ', spaces);
+    return lines.Select(line => indentation + line);
+  }
+
+  internal static string[] Lines(string value)
+  {
+    if (value is null)
+    {
+      throw new ArgumentNullException(nameof(value));
+    }
+
+    return value
+      .Replace("\r\n", "\n")
+      .Replace('\r', '\n')
+      .Split(new[] { '\n' }, StringSplitOptions.None);
+  }
+
+  private static string IdentifierSegment(string value)
+    => BareIdentifier.IsMatch(value) ? value : Quoted(value);
+
+  private static string Quoted(string value)
+  {
+    var result = new StringBuilder(value.Length + 2).Append('"');
+
+    foreach (var character in value)
+    {
+      result.Append(character switch
+      {
+        '\\' => "\\\\",
+        '"' => "\\\"",
+        '$' => "\\$",
+        '\r' => "\\r",
+        '\n' => "\\n",
+        '\t' => "\\t",
+        _ => character.ToString()
+      });
+    }
+
+    return result.Append('"').ToString();
+  }
+}

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -2,49 +2,20 @@ namespace d2;
 
 public static class Utils
 {
-  public static string StringifyBoolean(bool? value) => value switch
-  {
-    true => "true",
-    _ => "false"
-  };
+  public static string StringifyBoolean(bool? value) => D2Writer.Boolean(value is true);
 
   public static IEnumerable<string> AddLabelAndProperties(
     string name,
     string? label,
     IEnumerable<string> properties)
   {
-    var hasProperties = properties?.Any() ?? false;
-
-    string firstLine = name ?? string.Empty;
-    if (label != null || hasProperties)
-    {
-      firstLine += ":";
-    }
-
-    if (label != null)
-    {
-      firstLine += $" {label}";
-    }
-
-    if (hasProperties)
-    {
-      firstLine += " {";
-    }
-
-    if (properties != null && hasProperties)
-    {
-      return new List<string> { firstLine }
-        .Concat(Indent(properties))
-        .Append("}");
-    }
-
-    return new[] { firstLine };
+    return D2Writer.Object(name, label, properties);
   }
 
 
   public static IEnumerable<string> Indent(IEnumerable<string> items, int times = 2)
   {
-    return items.Select(item => " ".Repeat(times) + item);
+    return D2Writer.Indent(items, times);
   }
 
   public static string Repeat(this string value, int times)

--- a/test/UnitTests.cs
+++ b/test/UnitTests.cs
@@ -1,40 +1,225 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+
 namespace Tests;
 
 [TestClass]
 public class UnitTests
 {
   [TestMethod]
-  public void TestDiagram()
+  public void Diagram_PreservesSimpleReadableOutput()
   {
     var umbrella = new D2Shape("alphabet", "Alphabet Inc", Shape.Rectangle);
     var company = new D2Shape("google", "Google", Shape.Rectangle)
-	{
-		new D2Shape("gmail", "Gmail", Shape.Rectangle),
-		new D2Shape("meet", "Meet", Shape.Rectangle),
-		new D2Shape("deepmind", "DeepMind", Shape.Rectangle),
-	};
+    {
+      new D2Shape("gmail", "Gmail", Shape.Rectangle),
+      new D2Shape("meet", "Meet", Shape.Rectangle),
+      new D2Shape("deepmind", "DeepMind", Shape.Rectangle),
+    };
 
     var connection = new D2Connection(company.Name, umbrella.Name, Direction.TO, "BELONGS_TO");
 
     var diagram = new D2Diagram(new[] { umbrella, company }, new[] { connection });
-    var actual = diagram.ToString();
-    var expected = @"alphabet: Alphabet Inc {
-  shape: rectangle
-}
-google: Google {
-  gmail: Gmail {
-    shape: rectangle
-  }
-  meet: Meet {
-    shape: rectangle
-  }
-  deepmind: DeepMind {
-    shape: rectangle
-  }
-  shape: rectangle
-}
-google -> alphabet: BELONGS_TO";
+    var expected = Lines(
+      "alphabet: Alphabet Inc {",
+      "  shape: rectangle",
+      "}",
+      "google: Google {",
+      "  gmail: Gmail {",
+      "    shape: rectangle",
+      "  }",
+      "  meet: Meet {",
+      "    shape: rectangle",
+      "  }",
+      "  deepmind: DeepMind {",
+      "    shape: rectangle",
+      "  }",
+      "  shape: rectangle",
+      "}",
+      "google -> alphabet: BELONGS_TO");
 
-    Assert.AreEqual(expected, actual);
+    Assert.AreEqual(expected, diagram.ToString());
   }
+
+  [TestMethod]
+  public void Shape_QuotesAndEscapesUserControlledSyntax()
+  {
+    var shape = new D2Shape(
+      "service.api",
+      "API #1 \"public\" ${secret}\nnext",
+      Shape.Rectangle,
+      new D2Style("#112233", 2, "color \"blue\" #fff", true, 0.5, 4, false),
+      "top # center")
+    {
+      Icon = "https://example.com/icon \"dark\".svg#v1"
+    };
+
+    var expected = Lines(
+      "service.api: \"API #1 \\\"public\\\" \\${secret}\\nnext\" {",
+      "  icon: \"https://example.com/icon \\\"dark\\\".svg#v1\"",
+      "  shape: rectangle",
+      "  near: \"top # center\"",
+      "  style: {",
+      "    stroke: \"#112233\"",
+      "    stroke-width: 2",
+      "    fill: \"color \\\"blue\\\" #fff\"",
+      "    shadow: true",
+      "    opacity: 0.5",
+      "    stroke-dash: 4",
+      "    3d: false",
+      "  }",
+      "}");
+
+    Assert.AreEqual(expected, shape.ToString());
+  }
+
+  [TestMethod]
+  public void Shape_EmitsExplicitEmptyLabelAsEmptyString()
+  {
+    Assert.AreEqual("item: \"\"", new D2Shape("item", string.Empty).ToString());
+    Assert.AreEqual("item", new D2Shape("item", null).ToString());
+  }
+
+  [TestMethod]
+  public void Connection_QuotesEndpointsAndLabel()
+  {
+    var connection = new D2Connection(
+      "source.node",
+      "target # node",
+      Direction.BOTH,
+      "uses: \"secure\" ${token}");
+
+    Assert.AreEqual(
+      "source.node <-> \"target # node\": \"uses: \\\"secure\\\" \\${token}\"",
+      connection.ToString());
+  }
+
+  [TestMethod]
+  public void Style_UsesInvariantNumericFormatting()
+  {
+    var originalCulture = CultureInfo.CurrentCulture;
+    try
+    {
+      CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+      var style = new D2Style(null, 2, null, null, 0.25, 3, null);
+
+      StringAssert.Contains(style.ToString(), "opacity: 0.25");
+      StringAssert.Contains(style.ToString(), "stroke-width: 2");
+    }
+    finally
+    {
+      CultureInfo.CurrentCulture = originalCulture;
+    }
+  }
+
+  [TestMethod]
+  [DataRow(-0.01)]
+  [DataRow(1.01)]
+  [DataRow(double.NaN)]
+  [DataRow(double.PositiveInfinity)]
+  public void Style_RejectsInvalidOpacity(double opacity)
+  {
+    var style = new D2Style(null, null, null, null, opacity, null, null);
+    Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => style.ToString());
+  }
+
+  [TestMethod]
+  [DataRow(0.0, "opacity: 0")]
+  [DataRow(1.0, "opacity: 1")]
+  public void Style_AcceptsOpacityBoundaries(double opacity, string expected)
+  {
+    var style = new D2Style(null, null, null, null, opacity, null, null);
+    StringAssert.Contains(style.ToString(), expected);
+  }
+
+  [TestMethod]
+  public void Text_NormalizesAllNewlineConventions()
+  {
+    var text = new D2Text("label", "one\r\ntwo\rthree\nfour", "md", 1);
+
+    Assert.AreEqual(Lines("label:|md", "one", "two", "three", "four", "|"), text.ToString());
+  }
+
+  [TestMethod]
+  public void Text_IncreasesDelimiterWhenContentWouldCloseBlock()
+  {
+    var text = new D2Text("label.text", "one\n|\ntwo", "md", 1);
+
+    Assert.AreEqual(Lines("label.text:||md", "one", "|", "two", "||"), text.ToString());
+  }
+
+  [TestMethod]
+  public void Shape_QuotesUnsafePathSegmentsWithoutChangingPathSemantics()
+  {
+    var shape = new D2Shape("system.api#1.endpoint", null);
+
+    Assert.AreEqual("system.\"api#1\".endpoint", shape.ToString());
+  }
+
+  [TestMethod]
+  public void Text_RejectsInvalidDelimiterAndFormat()
+  {
+    Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new D2Text("label", "text", "md", 0).ToString());
+    Assert.ThrowsExactly<ArgumentException>(() => new D2Text("label", "text", "md|evil", 1).ToString());
+  }
+
+  [TestMethod]
+  public void GeneratedDiagram_PassesD2ValidationWhenCliIsAvailable()
+  {
+    var source = new D2Shape(
+      "service.api",
+      "API #1 \"public\" ${secret}",
+      Shape.Rectangle,
+      new D2Style("#112233", 2, "#ffffff", true, 0.5, 4, false))
+    {
+      Icon = "https://example.com/icon.svg#v1"
+    };
+    source.Add(new D2Text("tooltip", "first line\r\nsecond # line", "md", 1));
+    var target = new D2Shape("target#2", "Target: database", Shape.Cylinder);
+    var diagram = new D2Diagram(
+      new[] { source, target },
+      new[] { new D2Connection(source.Name, target.Name, Direction.TO, "calls # safely") });
+
+    var path = Path.Combine(Path.GetTempPath(), $"d2lang-cs-{Guid.NewGuid():N}.d2");
+    File.WriteAllText(path, diagram.ToString());
+
+    try
+    {
+      using var process = new Process
+      {
+        StartInfo = new ProcessStartInfo
+        {
+          FileName = "d2",
+          UseShellExecute = false,
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+        }
+      };
+      process.StartInfo.ArgumentList.Add("validate");
+      process.StartInfo.ArgumentList.Add(path);
+
+      try
+      {
+        process.Start();
+      }
+      catch (Win32Exception)
+      {
+        Assert.Inconclusive("The D2 CLI is not installed; parser-backed validation was skipped.");
+        return;
+      }
+
+      var standardOutput = process.StandardOutput.ReadToEnd();
+      var standardError = process.StandardError.ReadToEnd();
+      process.WaitForExit();
+
+      Assert.AreEqual(0, process.ExitCode, $"d2 validate failed.{Environment.NewLine}{standardOutput}{standardError}{Environment.NewLine}{diagram}");
+    }
+    finally
+    {
+      File.Delete(path);
+    }
+  }
+
+  private static string Lines(params string[] lines) => string.Join(Environment.NewLine, lines);
 }


### PR DESCRIPTION
## What changed

- centralizes D2 references, strings, numbers, indentation, and newline serialization
- quotes and escapes syntax-bearing user values while preserving dotted path semantics
- models opacity as a finite floating-point value from 0 through 1
- normalizes block-string newlines and avoids delimiter collisions
- expands coverage to 16 focused tests, including a real `d2 validate` integration test

## Why

The previous implementation interpolated user-controlled values directly into D2. Values such as hex colors or URL fragments containing `#` could be parsed as comments and produce invalid diagrams.

## Validation

- `dotnet test test/Tests.csproj --configuration Release --no-restore --disable-build-servers`: 16/16 passed
- parser-backed `d2 validate`: passed
- `git diff --check`: passed

## Compatibility

Changing `D2Style.Opacity` from `int?` to `double?` is source-compatible for integer callers but is a binary API change. A major package version should be used when releasing the complete stack.