### PR TITLE
feat: entity framework core schema generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,26 +130,40 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Restore
-        run: dotnet restore src/d2lang-cs.csproj
+        run: dotnet restore d2lang-cs.sln
 
-      - name: Pack with package validation
+      - name: Pack core package with package validation
         run: dotnet pack src/d2lang-cs.csproj --configuration Release --no-restore --output artifacts/packages -p:ContinuousIntegrationBuild=true -p:EnablePackageValidation=true
+
+      - name: Pack Entity Framework Core integration
+        run: dotnet pack src/D2Lang.EntityFrameworkCore/D2Lang.EntityFrameworkCore.csproj --configuration Release --no-restore --output artifacts/packages -p:ContinuousIntegrationBuild=true -p:EnablePackageValidation=true
 
       - name: Inspect package contents
         shell: bash
         run: |
-          package_path=$(find artifacts/packages -maxdepth 1 -name '*.nupkg' ! -name '*.snupkg' -print -quit)
-          test -n "$package_path"
-          unzip -l "$package_path" | tee artifacts/package-contents.txt
-          grep -q 'lib/net10.0/d2lang-cs.dll' artifacts/package-contents.txt
-          grep -q 'README.md' artifacts/package-contents.txt
-          grep -q 'd2_logo.png' artifacts/package-contents.txt
+          core_package_path=$(find artifacts/packages -maxdepth 1 -iname 'd2lang-cs.*.nupkg' ! -name '*.snupkg' -print -quit)
+          efcore_package_path=$(find artifacts/packages -maxdepth 1 -iname 'd2lang.entityframeworkcore.*.nupkg' ! -name '*.snupkg' -print -quit)
+          test -n "$core_package_path"
+          test -n "$efcore_package_path"
+
+          unzip -l "$core_package_path" | tee artifacts/core-package-contents.txt
+          grep -q 'lib/net10.0/d2lang-cs.dll' artifacts/core-package-contents.txt
+          grep -q 'README.md' artifacts/core-package-contents.txt
+          grep -q 'd2_logo.png' artifacts/core-package-contents.txt
+
+          unzip -l "$efcore_package_path" | tee artifacts/efcore-package-contents.txt
+          grep -q 'lib/net8.0/D2Lang.EntityFrameworkCore.dll' artifacts/efcore-package-contents.txt
+          grep -q 'lib/net10.0/D2Lang.EntityFrameworkCore.dll' artifacts/efcore-package-contents.txt
+          grep -q 'README.md' artifacts/efcore-package-contents.txt
+          grep -q 'd2_logo.png' artifacts/efcore-package-contents.txt
 
       - name: Install package in a clean consumer project
         shell: bash
         run: |
           dotnet new console --framework net10.0 --output artifacts/package-smoke --no-restore
-          dotnet add artifacts/package-smoke/package-smoke.csproj package d2lang-cs --prerelease --source "$PWD/artifacts/packages"
+          dotnet new nugetconfig --output artifacts/package-smoke --force
+          dotnet nuget add source "$PWD/artifacts/packages" --name local-packages --configfile artifacts/package-smoke/nuget.config
+          dotnet add artifacts/package-smoke/package-smoke.csproj package D2Lang.EntityFrameworkCore --prerelease
           dotnet build artifacts/package-smoke/package-smoke.csproj --configuration Release --no-restore
 
       - name: Upload package
@@ -158,6 +172,7 @@ jobs:
           name: nuget-package
           path: |
             artifacts/packages/*.nupkg
-            artifacts/package-contents.txt
+            artifacts/core-package-contents.txt
+            artifacts/efcore-package-contents.txt
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,21 @@ jobs:
       - name: Test
         run: dotnet test test/Tests.csproj --configuration Release --no-restore -p:ContinuousIntegrationBuild=true
 
-      - name: Pack with package validation
+      - name: Pack core package with package validation
         run: >-
           dotnet pack src/d2lang-cs.csproj
+          --configuration Release
+          --no-restore
+          --output artifacts/packages
+          -p:PackageVersion=${{ steps.package.outputs.version }}
+          -p:ContinuousIntegrationBuild=true
+          -p:EnablePackageValidation=true
+          -p:IncludeSymbols=true
+          -p:SymbolPackageFormat=snupkg
+
+      - name: Pack Entity Framework Core integration
+        run: >-
+          dotnet pack src/D2Lang.EntityFrameworkCore/D2Lang.EntityFrameworkCore.csproj
           --configuration Release
           --no-restore
           --output artifacts/packages
@@ -68,7 +80,7 @@ jobs:
       - name: Upload release packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: d2lang-cs-${{ steps.package.outputs.version }}
+          name: d2lang-packages-${{ steps.package.outputs.version }}
           path: artifacts/packages/*.*nupkg
           if-no-files-found: error
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -152,6 +152,25 @@ var import = new D2RawStatement("...@architecture.d2");
 
 For Markdown, LaTeX, and other D2 block strings, use `D2Text`. It normalizes line endings and automatically lengthens the pipe delimiter when the contents would otherwise close the block.
 
+## Entity Framework Core integration
+
+Install the separate `D2Lang.EntityFrameworkCore` package to keep a D2 database diagram synchronized with an EF Core relational model:
+
+```bash
+dotnet add package D2Lang.EntityFrameworkCore
+```
+
+Chain schema generation after the normal context registration:
+
+```csharp
+builder.Services
+    .AddDbContext<AppDbContext>(options =>
+        options.UseSqlServer(builder.Configuration.GetConnectionString("Database")))
+    .AddD2Schema<AppDbContext>("docs/database-schema.d2");
+```
+
+The integration writes the diagram when the host starts, without connecting to the database, and leaves an unchanged file untouched. It includes tables, columns, provider store types, nullability, primary and unique keys, foreign keys, and relationship edges. Applications without a generic host can call `dbContext.ToD2Diagram()` directly.
+
 ## Supported features
 
 - Shapes, nested containers, the modeled D2 shape kinds, icons, dimensions, links, tooltips, and relative placement

--- a/d2lang-cs.sln
+++ b/d2lang-cs.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "d2lang-cs", "src\d2lang-cs.csproj", "{BB0ABCF8-5B09-438A-9FCE-9CD3D70E4CBB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "D2Lang.EntityFrameworkCore", "src\D2Lang.EntityFrameworkCore\D2Lang.EntityFrameworkCore.csproj", "{89767467-C35E-4A72-9D3D-12CA41D48A82}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "example", "example", "{5C588B55-FBDC-4C2F-B65F-14BB31282E33}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "d2-sample-cli", "example\cli\d2-sample-cli.csproj", "{327CF66B-11FC-460F-A018-F0A602482A03}"
@@ -21,6 +23,10 @@ Global
 		{BB0ABCF8-5B09-438A-9FCE-9CD3D70E4CBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BB0ABCF8-5B09-438A-9FCE-9CD3D70E4CBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BB0ABCF8-5B09-438A-9FCE-9CD3D70E4CBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89767467-C35E-4A72-9D3D-12CA41D48A82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89767467-C35E-4A72-9D3D-12CA41D48A82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89767467-C35E-4A72-9D3D-12CA41D48A82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89767467-C35E-4A72-9D3D-12CA41D48A82}.Release|Any CPU.Build.0 = Release|Any CPU
 		{327CF66B-11FC-460F-A018-F0A602482A03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{327CF66B-11FC-460F-A018-F0A602482A03}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{327CF66B-11FC-460F-A018-F0A602482A03}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/D2Lang.EntityFrameworkCore/D2Lang.EntityFrameworkCore.csproj
+++ b/src/D2Lang.EntityFrameworkCore/D2Lang.EntityFrameworkCore.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RootNamespace>d2.EntityFrameworkCore</RootNamespace>
+
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>local</VersionSuffix>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+    <DebugType>portable</DebugType>
+    <EnableSourceLink>true</EnableSourceLink>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EnablePackageValidation>true</EnablePackageValidation>
+
+    <PackageId>D2Lang.EntityFrameworkCore</PackageId>
+    <Title>D2 for Entity Framework Core</Title>
+    <Authors>Stephan van Stekelenburg</Authors>
+    <Copyright>Copyright (c) Stephan van Stekelenburg</Copyright>
+    <RepositoryUrl>https://github.com/Stephanvs/d2lang-cs.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/Stephanvs/d2lang-cs</PackageProjectUrl>
+    <PackageTags>D2;Entity Framework Core;EF Core;Database;Schema;Diagram</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Description>Generate D2 SQL-table diagrams automatically from Entity Framework Core relational models.</Description>
+    <PackageIcon>d2_logo.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.29" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../d2lang-cs.csproj" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+    <None Include="../../docs/assets/img/d2_logo.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+</Project>

--- a/src/D2Lang.EntityFrameworkCore/D2ModelExtensions.cs
+++ b/src/D2Lang.EntityFrameworkCore/D2ModelExtensions.cs
@@ -1,0 +1,149 @@
+using d2;
+using d2.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>Extensions for converting Entity Framework Core relational models to D2.</summary>
+public static class D2ModelExtensions
+{
+  /// <summary>Creates a D2 SQL-table diagram from a context's relational model.</summary>
+  /// <typeparam name="TContext">The Entity Framework Core context type.</typeparam>
+  /// <param name="context">The context whose model is converted.</param>
+  /// <param name="configure">Optional diagram-generation settings.</param>
+  /// <returns>A diagram containing the model's tables, columns, constraints, and relationships.</returns>
+  public static D2Diagram ToD2Diagram<TContext>(
+    this TContext context,
+    Action<D2SchemaOptions>? configure = null)
+    where TContext : DbContext
+  {
+    if (context is null) throw new ArgumentNullException(nameof(context));
+    return context.Model.ToD2Diagram(configure);
+  }
+
+  /// <summary>Creates a D2 SQL-table diagram from an Entity Framework Core relational model.</summary>
+  /// <param name="model">The relational model to convert.</param>
+  /// <param name="configure">Optional diagram-generation settings.</param>
+  /// <returns>A diagram containing the model's tables, columns, constraints, and relationships.</returns>
+  public static D2Diagram ToD2Diagram(
+    this IModel model,
+    Action<D2SchemaOptions>? configure = null)
+  {
+    if (model is null) throw new ArgumentNullException(nameof(model));
+
+    var options = new D2SchemaOptions();
+    configure?.Invoke(options);
+    options.Validate();
+    return CreateD2Diagram(model, options);
+  }
+
+  internal static D2Diagram CreateD2Diagram(IModel model, D2SchemaOptions options)
+  {
+    var tables = model.GetRelationalModel().Tables
+      .OrderBy(table => table.Schema, StringComparer.Ordinal)
+      .ThenBy(table => table.Name, StringComparer.Ordinal)
+      .ToList();
+
+    var tableReferences = tables.ToDictionary(
+      table => table,
+      table => GetTableReference(table, options));
+
+    var duplicateReference = tableReferences.Values
+      .GroupBy(reference => reference, StringComparer.Ordinal)
+      .FirstOrDefault(group => group.Count() > 1);
+    if (duplicateReference is not null)
+    {
+      throw new InvalidOperationException(
+        $"Multiple database tables map to the D2 key '{duplicateReference.Key}'. " +
+        "Enable database schemas to disambiguate them.");
+    }
+
+    var statements = new List<D2Statement>();
+    foreach (var table in tables)
+    {
+      var sqlTable = new D2SqlTable(tableReferences[table]);
+      foreach (var column in table.Columns
+        .OrderByDescending(column => table.PrimaryKey?.Columns.Contains(column) == true)
+        .ThenBy(column => column.Name, StringComparer.Ordinal))
+      {
+        sqlTable.Add(new D2SqlColumn(
+          column.Name,
+          GetColumnType(column, options),
+          GetColumnConstraints(table, column)));
+      }
+
+      statements.Add(sqlTable);
+    }
+
+    if (options.IncludeForeignKeyConnections)
+    {
+      statements.AddRange(CreateForeignKeyConnections(tables, tableReferences, options));
+    }
+
+    return new D2Diagram(statements);
+  }
+
+  private static string GetTableReference(ITable table, D2SchemaOptions options)
+    => options.IncludeDatabaseSchemas && !string.IsNullOrWhiteSpace(table.Schema)
+      ? $"{table.Schema}.{table.Name}"
+      : table.Name;
+
+  private static string GetColumnType(IColumn column, D2SchemaOptions options)
+  {
+    if (!options.IncludeNullability)
+    {
+      return column.StoreType;
+    }
+
+    return $"{column.StoreType} {(column.IsNullable ? "NULL" : "NOT NULL")}";
+  }
+
+  private static D2SqlConstraint[] GetColumnConstraints(ITable table, IColumn column)
+  {
+    var constraints = new List<D2SqlConstraint>();
+
+    if (table.PrimaryKey?.Columns.Contains(column) == true)
+    {
+      constraints.Add(D2SqlConstraint.PrimaryKey);
+    }
+
+    if (table.ForeignKeyConstraints.Any(foreignKey => foreignKey.Columns.Contains(column)))
+    {
+      constraints.Add(D2SqlConstraint.ForeignKey);
+    }
+
+    var belongsToUniqueConstraint = table.UniqueConstraints.Any(
+      constraint => !ReferenceEquals(constraint, table.PrimaryKey) && constraint.Columns.Contains(column));
+    var belongsToUniqueIndex = table.Indexes.Any(
+      index => index.IsUnique && index.Columns.Contains(column));
+    if (belongsToUniqueConstraint || belongsToUniqueIndex)
+    {
+      constraints.Add(D2SqlConstraint.Unique);
+    }
+
+    return constraints.ToArray();
+  }
+
+  private static IEnumerable<D2Statement> CreateForeignKeyConnections(
+    IEnumerable<ITable> tables,
+    IReadOnlyDictionary<ITable, string> tableReferences,
+    D2SchemaOptions options)
+  {
+    foreach (var table in tables)
+    {
+      foreach (var foreignKey in table.ForeignKeyConstraints.OrderBy(
+        foreignKey => foreignKey.Name,
+        StringComparer.Ordinal))
+      {
+        var columnCount = Math.Min(foreignKey.Columns.Count, foreignKey.PrincipalColumns.Count);
+        for (var index = 0; index < columnCount; index++)
+        {
+          var dependent = $"{tableReferences[table]}.{foreignKey.Columns[index].Name}";
+          var principal = $"{tableReferences[foreignKey.PrincipalTable]}.{foreignKey.PrincipalColumns[index].Name}";
+          var label = options.IncludeForeignKeyNames ? foreignKey.Name : null;
+          yield return new D2Connection(dependent, principal, Direction.To, label);
+        }
+      }
+    }
+  }
+}

--- a/src/D2Lang.EntityFrameworkCore/D2SchemaHostedService.cs
+++ b/src/D2Lang.EntityFrameworkCore/D2SchemaHostedService.cs
@@ -1,0 +1,89 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace d2.EntityFrameworkCore;
+
+internal sealed class D2SchemaHostedService<TContext> : IHostedService
+  where TContext : DbContext
+{
+  private readonly IServiceScopeFactory _scopeFactory;
+  private readonly IHostEnvironment _environment;
+  private readonly IOptionsMonitor<D2SchemaOptions> _options;
+  private readonly ILogger<D2SchemaHostedService<TContext>> _logger;
+
+  public D2SchemaHostedService(
+    IServiceScopeFactory scopeFactory,
+    IHostEnvironment environment,
+    IOptionsMonitor<D2SchemaOptions> options,
+    ILogger<D2SchemaHostedService<TContext>> logger)
+  {
+    _scopeFactory = scopeFactory;
+    _environment = environment;
+    _options = options;
+    _logger = logger;
+  }
+
+  public async Task StartAsync(CancellationToken cancellationToken)
+  {
+    var options = _options.Get(D2SchemaRegistration.OptionsName<TContext>());
+    options.Validate();
+
+    using var scope = _scopeFactory.CreateScope();
+    var context = scope.ServiceProvider.GetRequiredService<TContext>();
+    var diagram = D2ModelExtensions.CreateD2Diagram(context.Model, options);
+    var source = NormalizeSource(diagram.ToString());
+    var outputPath = ResolveOutputPath(options.OutputPath);
+
+    if (File.Exists(outputPath))
+    {
+      var existing = await File.ReadAllTextAsync(outputPath, cancellationToken).ConfigureAwait(false);
+      if (string.Equals(existing, source, StringComparison.Ordinal))
+      {
+        _logger.LogDebug("D2 database schema is unchanged at {OutputPath}.", outputPath);
+        return;
+      }
+    }
+
+    var directory = Path.GetDirectoryName(outputPath)
+      ?? throw new InvalidOperationException($"The D2 schema output path '{outputPath}' has no directory.");
+    Directory.CreateDirectory(directory);
+
+    var temporaryPath = $"{outputPath}.{Guid.NewGuid():N}.tmp";
+    try
+    {
+      await File.WriteAllTextAsync(
+        temporaryPath,
+        source,
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        cancellationToken).ConfigureAwait(false);
+      File.Move(temporaryPath, outputPath, overwrite: true);
+    }
+    finally
+    {
+      if (File.Exists(temporaryPath))
+      {
+        File.Delete(temporaryPath);
+      }
+    }
+
+    _logger.LogInformation("Generated D2 database schema at {OutputPath}.", outputPath);
+  }
+
+  public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+  private string ResolveOutputPath(string outputPath)
+    => Path.GetFullPath(
+      Path.IsPathRooted(outputPath)
+        ? outputPath
+        : Path.Combine(_environment.ContentRootPath, outputPath));
+
+  private static string NormalizeSource(string source)
+  {
+    var normalized = source.Replace("\r\n", "\n").Replace('\r', '\n');
+    return normalized.Length == 0 ? normalized : $"{normalized.TrimEnd('\n')}\n";
+  }
+}

--- a/src/D2Lang.EntityFrameworkCore/D2SchemaOptions.cs
+++ b/src/D2Lang.EntityFrameworkCore/D2SchemaOptions.cs
@@ -1,0 +1,31 @@
+namespace d2.EntityFrameworkCore;
+
+/// <summary>Controls how an Entity Framework Core relational model is represented in D2.</summary>
+public sealed class D2SchemaOptions
+{
+  /// <summary>
+  /// Gets or sets the generated <c>.d2</c> file path. Relative paths are resolved
+  /// from the host content root.
+  /// </summary>
+  public string OutputPath { get; set; } = "database-schema.d2";
+
+  /// <summary>Gets or sets whether table keys include their database schema.</summary>
+  public bool IncludeDatabaseSchemas { get; set; } = true;
+
+  /// <summary>Gets or sets whether column types include <c>NULL</c> or <c>NOT NULL</c>.</summary>
+  public bool IncludeNullability { get; set; } = true;
+
+  /// <summary>Gets or sets whether foreign keys are rendered as column-to-column connections.</summary>
+  public bool IncludeForeignKeyConnections { get; set; } = true;
+
+  /// <summary>Gets or sets whether foreign-key constraint names label their connections.</summary>
+  public bool IncludeForeignKeyNames { get; set; }
+
+  internal void Validate()
+  {
+    if (string.IsNullOrWhiteSpace(OutputPath))
+    {
+      throw new InvalidOperationException("A D2 schema output path is required.");
+    }
+  }
+}

--- a/src/D2Lang.EntityFrameworkCore/D2SchemaServiceCollectionExtensions.cs
+++ b/src/D2Lang.EntityFrameworkCore/D2SchemaServiceCollectionExtensions.cs
@@ -1,0 +1,52 @@
+using d2.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>Registration extensions for automatic EF Core schema generation.</summary>
+public static class D2SchemaServiceCollectionExtensions
+{
+  /// <summary>
+  /// Generates a D2 SQL-table schema from <typeparamref name="TContext"/> when the host starts.
+  /// </summary>
+  /// <typeparam name="TContext">The registered Entity Framework Core context type.</typeparam>
+  /// <param name="services">The application's service collection.</param>
+  /// <param name="outputPath">
+  /// The generated <c>.d2</c> path. Relative paths are resolved from the host content root.
+  /// </param>
+  /// <param name="configure">Optional diagram-generation settings.</param>
+  /// <returns>The same service collection for continued registration.</returns>
+  public static IServiceCollection AddD2Schema<TContext>(
+    this IServiceCollection services,
+    string outputPath,
+    Action<D2SchemaOptions>? configure = null)
+    where TContext : DbContext
+  {
+    if (services is null) throw new ArgumentNullException(nameof(services));
+    if (string.IsNullOrWhiteSpace(outputPath))
+    {
+      throw new ArgumentException("A D2 schema output path is required.", nameof(outputPath));
+    }
+
+    services
+      .AddOptions<D2SchemaOptions>(D2SchemaRegistration.OptionsName<TContext>())
+      .Configure(options =>
+      {
+        options.OutputPath = outputPath;
+        configure?.Invoke(options);
+      });
+
+    services.TryAddEnumerable(
+      ServiceDescriptor.Singleton<IHostedService, D2SchemaHostedService<TContext>>());
+    return services;
+  }
+}
+
+internal static class D2SchemaRegistration
+{
+  internal static string OptionsName<TContext>()
+    => typeof(TContext).AssemblyQualifiedName
+      ?? throw new InvalidOperationException("The Entity Framework Core context type has no assembly-qualified name.");
+}

--- a/src/D2Lang.EntityFrameworkCore/README.md
+++ b/src/D2Lang.EntityFrameworkCore/README.md
@@ -1,0 +1,49 @@
+# D2Lang.EntityFrameworkCore
+
+Generate a D2 SQL-table diagram directly from an Entity Framework Core relational model.
+
+## Install
+
+```bash
+dotnet add package D2Lang.EntityFrameworkCore
+```
+
+The package references `d2lang-cs` transitively. It supports EF Core applications targeting .NET 8 or .NET 10.
+
+## Automatic generation
+
+Chain `AddD2Schema` after the normal context registration:
+
+```csharp
+builder.Services
+    .AddDbContext<AppDbContext>(options =>
+        options.UseSqlServer(builder.Configuration.GetConnectionString("Database")))
+    .AddD2Schema<AppDbContext>("docs/database-schema.d2");
+```
+
+The file is generated when the host starts. Relative paths use the host content root. The generator reads EF Core's in-memory relational model, so it does not connect to the database. Files are replaced only when their content changes.
+
+The output contains database tables, columns, provider store types, nullability, primary keys, unique columns, foreign-key constraints, and column-to-column foreign-key connections. Use the independently installed D2 CLI to render the generated source:
+
+```bash
+d2 docs/database-schema.d2 docs/database-schema.svg
+```
+
+Generation can be customized during registration:
+
+```csharp
+.AddD2Schema<AppDbContext>("docs/database-schema.d2", options =>
+{
+    options.IncludeDatabaseSchemas = true;
+    options.IncludeNullability = true;
+    options.IncludeForeignKeyConnections = true;
+    options.IncludeForeignKeyNames = false;
+});
+```
+
+For applications that do not use the .NET generic host, create the diagram directly:
+
+```csharp
+var diagram = dbContext.ToD2Diagram();
+var source = diagram.ToString();
+```

--- a/src/d2lang-cs.csproj
+++ b/src/d2lang-cs.csproj
@@ -39,6 +39,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The EF Core integration is a separate project and NuGet package. -->
+    <Compile Remove="D2Lang.EntityFrameworkCore/**/*.cs" />
+
     <None Include="../docs/assets/img/banner.png" Pack="true" PackagePath="docs/assets/img/" />
     <None Include="../docs/assets/img/diagram.png" Pack="true" PackagePath="docs/assets/img/" />
     <None Include="../docs/assets/img/d2_logo.png" Pack="true" PackagePath="" />

--- a/test/EntityFrameworkCoreTests.cs
+++ b/test/EntityFrameworkCoreTests.cs
@@ -1,0 +1,203 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Tests;
+
+[TestClass]
+public class EntityFrameworkCoreTests
+{
+  [TestMethod]
+  public void ToD2Diagram_MapsRelationalTablesColumnsConstraintsAndRelationships()
+  {
+    using var context = CreateContext();
+
+    var actual = context.ToD2Diagram().ToString();
+
+    var expected = string.Join(
+      Environment.NewLine,
+      "catalog.posts: {",
+      "  id: int NOT NULL { constraint: primary_key }",
+      "  title: \"nvarchar(max) NOT NULL\"",
+      "  user_id: int NOT NULL { constraint: foreign_key }",
+      "  shape: sql_table",
+      "}",
+      "catalog.users: {",
+      "  id: int NOT NULL { constraint: primary_key }",
+      "  email: \"nvarchar(450) NOT NULL\" { constraint: unique }",
+      "  shape: sql_table",
+      "}",
+      "catalog.posts.user_id -> catalog.users.id");
+
+    Assert.AreEqual(expected, actual);
+  }
+
+  [TestMethod]
+  public void ToD2Diagram_CanOmitSchemaNullabilityAndConnections()
+  {
+    using var context = CreateContext();
+
+    var actual = context.ToD2Diagram(options =>
+    {
+      options.IncludeDatabaseSchemas = false;
+      options.IncludeNullability = false;
+      options.IncludeForeignKeyConnections = false;
+    }).ToString();
+
+    StringAssert.Contains(actual, "posts: {");
+    StringAssert.Contains(actual, "title: \"nvarchar(max)\"");
+    Assert.IsFalse(actual.Contains("catalog.", StringComparison.Ordinal));
+    Assert.IsFalse(actual.Contains(" -> ", StringComparison.Ordinal));
+  }
+
+  [TestMethod]
+  public async Task AddD2Schema_GeneratesFileAtHostStartupAndSkipsUnchangedContent()
+  {
+    var contentRoot = Path.Combine(Path.GetTempPath(), $"d2-efcore-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(contentRoot);
+
+    try
+    {
+      var outputPath = Path.Combine(contentRoot, "docs", "schema.d2");
+      using (var host = CreateHost(contentRoot))
+      {
+        await host.StartAsync();
+        Assert.IsTrue(File.Exists(outputPath));
+        var source = await File.ReadAllTextAsync(outputPath);
+        StringAssert.Contains(source, "catalog.users");
+        await host.StopAsync();
+      }
+
+      var unchangedTimestamp = DateTime.UtcNow.AddMinutes(-5);
+      File.SetLastWriteTimeUtc(outputPath, unchangedTimestamp);
+
+      using (var host = CreateHost(contentRoot))
+      {
+        await host.StartAsync();
+        Assert.AreEqual(unchangedTimestamp, File.GetLastWriteTimeUtc(outputPath));
+        await host.StopAsync();
+      }
+    }
+    finally
+    {
+      Directory.Delete(contentRoot, recursive: true);
+    }
+  }
+
+  [TestMethod]
+  public void GeneratedEfSchema_PassesD2ValidationWhenCliIsAvailable()
+  {
+    using var context = CreateContext();
+    var source = context.ToD2Diagram().ToString();
+    var path = Path.Combine(Path.GetTempPath(), $"d2lang-cs-efcore-{Guid.NewGuid():N}.d2");
+    File.WriteAllText(path, source);
+
+    try
+    {
+      using var process = new Process
+      {
+        StartInfo = new ProcessStartInfo
+        {
+          FileName = "d2",
+          UseShellExecute = false,
+          RedirectStandardOutput = true,
+          RedirectStandardError = true,
+        }
+      };
+      process.StartInfo.ArgumentList.Add("validate");
+      process.StartInfo.ArgumentList.Add(path);
+
+      try
+      {
+        process.Start();
+      }
+      catch (Win32Exception)
+      {
+        Assert.Inconclusive("The D2 CLI is not installed; parser-backed validation was skipped.");
+        return;
+      }
+
+      var output = process.StandardOutput.ReadToEnd();
+      var error = process.StandardError.ReadToEnd();
+      process.WaitForExit();
+      Assert.AreEqual(
+        0,
+        process.ExitCode,
+        $"d2 validate failed.{Environment.NewLine}{output}{error}{Environment.NewLine}{source}");
+    }
+    finally
+    {
+      File.Delete(path);
+    }
+  }
+
+  private static IHost CreateHost(string contentRoot)
+  {
+    var settings = new HostApplicationBuilderSettings { ContentRootPath = contentRoot };
+    var builder = Host.CreateApplicationBuilder(settings);
+    builder.Services
+      .AddDbContext<SchemaDbContext>(options => options.UseSqlServer(TestConnectionString))
+      .AddD2Schema<SchemaDbContext>("docs/schema.d2");
+    return builder.Build();
+  }
+
+  private static SchemaDbContext CreateContext()
+  {
+    var options = new DbContextOptionsBuilder<SchemaDbContext>()
+      .UseSqlServer(TestConnectionString)
+      .Options;
+    return new SchemaDbContext(options);
+  }
+
+  private const string TestConnectionString =
+    "Server=localhost;Database=d2_schema_tests;Integrated Security=true;TrustServerCertificate=true";
+
+  private sealed class SchemaDbContext : DbContext
+  {
+    public SchemaDbContext(DbContextOptions<SchemaDbContext> options)
+      : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+      modelBuilder.Entity<User>(entity =>
+      {
+        entity.ToTable("users", "catalog");
+        entity.HasKey(user => user.Id);
+        entity.Property(user => user.Id).HasColumnName("id");
+        entity.Property(user => user.Email).HasColumnName("email").IsRequired();
+        entity.HasIndex(user => user.Email).IsUnique();
+      });
+
+      modelBuilder.Entity<Post>(entity =>
+      {
+        entity.ToTable("posts", "catalog");
+        entity.HasKey(post => post.Id);
+        entity.Property(post => post.Id).HasColumnName("id");
+        entity.Property(post => post.Title).HasColumnName("title").IsRequired();
+        entity.Property(post => post.UserId).HasColumnName("user_id");
+        entity.HasOne(post => post.User)
+          .WithMany(user => user.Posts)
+          .HasForeignKey(post => post.UserId);
+      });
+    }
+  }
+
+  private sealed class User
+  {
+    public int Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public List<Post> Posts { get; set; } = new();
+  }
+
+  private sealed class Post
+  {
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public int UserId { get; set; }
+    public User User { get; set; } = null!;
+  }
+}

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
@@ -17,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\src\D2Lang.EntityFrameworkCore\D2Lang.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\src\d2lang-cs.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## What changed

- adds a separate `D2Lang.EntityFrameworkCore` NuGet package targeting .NET 8 and .NET 10
- converts EF Core relational models into typed D2 SQL tables, constraints, and foreign-key connections
- adds `AddD2Schema<TContext>` for automatic startup generation and `ToD2Diagram()` for direct use
- resolves relative output paths from the host content root, writes atomically, and skips unchanged files
- adds documentation, CI package validation, release publishing, and parser-backed tests

## Why

Database diagrams should remain synchronized with the EF Core model instead of being maintained manually. The integration reads EF metadata without connecting to the database and produces source that can be rendered by the D2 CLI.

## Validation

- multi-target Release build: 0 warnings, 0 errors
- tests: 37/37 passed, including real `d2 validate`
- NuGet package validation and `.nupkg`/`.snupkg` inspection passed
- clean .NET 8 and .NET 10 consumer builds passed
- NuGet vulnerability audit found no vulnerable dependencies
- simulated 2.0.0 release preserved the correct `d2lang-cs` package dependency

## Dependency

PR #5 is merged; this branch is based on its merge commit.